### PR TITLE
Hotfix misspelling variable name in notification worker

### DIFF
--- a/app/workers/telegram_chatbot/notification_worker.rb
+++ b/app/workers/telegram_chatbot/notification_worker.rb
@@ -7,7 +7,7 @@ module TelegramChatbot
     def perform(message, group_id = nil)
       return if !(group_id.present? && message.present?)
 
-      Notification.notify(message, group)
+      Notification.notify(message, group_id)
     end
   end
 end


### PR DESCRIPTION
- Hotfix misspelling variable name in notification worker